### PR TITLE
Refactor P3 reference link

### DIFF
--- a/levels/Level0/Recipes/99Bottles.html
+++ b/levels/Level0/Recipes/99Bottles.html
@@ -16,6 +16,5 @@
 </li><li>Do not repeat any of the lyrics in your code - use a for loop!
 </li>
     <li>Look out for the changes you will need to make to the lyrics when you get down to 1 or zero bottles.</li></ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/AmazingRings.html
+++ b/levels/Level0/Recipes/AmazingRings.html
@@ -19,7 +19,5 @@
     
     </ol>
     
-    
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/BananaSplit.html
+++ b/levels/Level0/Recipes/BananaSplit.html
@@ -39,8 +39,7 @@ text("word", xPos, yPos);
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/Bananas4Eva.html
+++ b/levels/Level0/Recipes/Bananas4Eva.html
@@ -36,8 +36,7 @@
                                   <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>                              
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/Bullseye.html
+++ b/levels/Level0/Recipes/Bullseye.html
@@ -24,6 +24,5 @@
             </li>   
         </ol>
         
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+        <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/Bumblebee.html
+++ b/levels/Level0/Recipes/Bumblebee.html
@@ -16,6 +16,5 @@
             <li>Make sure you SAVE YOUR CODE when you are done. 
             </li>  
     </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/DotRace.html
+++ b/levels/Level0/Recipes/DotRace.html
@@ -13,6 +13,6 @@
             <li>Make sure you SAVE YOUR CODE when you are done. 
             </li>
                                     
-    </ol><a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    </ol>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/GooglyEyes.html
+++ b/levels/Level0/Recipes/GooglyEyes.html
@@ -64,6 +64,5 @@
             <li>Make sure you SAVE YOUR CODE when you are done. 
             </li>
                             </ol>
-    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/IceCreamShop.html
+++ b/levels/Level0/Recipes/IceCreamShop.html
@@ -12,6 +12,5 @@
             <li>Make sure you SAVE YOUR CODE when you are done. 
             </li>    
     </ol>
-    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/LogicalDot.html
+++ b/levels/Level0/Recipes/LogicalDot.html
@@ -36,8 +36,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/MakeAMeme.html
+++ b/levels/Level0/Recipes/MakeAMeme.html
@@ -36,8 +36,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/MolesInHoles.html
+++ b/levels/Level0/Recipes/MolesInHoles.html
@@ -11,6 +11,5 @@
     <li>Make sure you SAVE YOUR CODE when you are done. 
 </li>
     </ol>
-    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/Pizza.html
+++ b/levels/Level0/Recipes/Pizza.html
@@ -97,8 +97,7 @@ sound.rewind();
                                 </li>
                             </ol>
                             
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/Pong.html
+++ b/levels/Level0/Recipes/Pong.html
@@ -60,6 +60,5 @@ int paddleLength) {
 </li>            <li>Make sure you SAVE YOUR CODE when you are done. 
             </li>    
     </ol>
-    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/Race.html
+++ b/levels/Level0/Recipes/Race.html
@@ -36,8 +36,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/ShapesAndColors.html
+++ b/levels/Level0/Recipes/ShapesAndColors.html
@@ -38,8 +38,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/SlipperyDot.html
+++ b/levels/Level0/Recipes/SlipperyDot.html
@@ -11,5 +11,5 @@
         <li>Make sure you SAVE YOUR CODE when you are done. 
     </li>
     </ol>
-    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a><div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
+    <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div></body></html>

--- a/levels/Level0/Recipes/TashMe.html
+++ b/levels/Level0/Recipes/TashMe.html
@@ -36,8 +36,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/TastyTomato.html
+++ b/levels/Level0/Recipes/TastyTomato.html
@@ -45,8 +45,7 @@
                                 </li>
                                 
                             </ol>
-                    <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/TerminatorCat.html
+++ b/levels/Level0/Recipes/TerminatorCat.html
@@ -38,8 +38,7 @@
                         <li>Make sure you SAVE YOUR CODE when you are done. 
                         </li>
 </ol>
-                        <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                     <div style="clear:both;"></div>
                 </div>
             </div>

--- a/levels/Level0/Recipes/UnicornsOnARainbow.html
+++ b/levels/Level0/Recipes/UnicornsOnARainbow.html
@@ -36,8 +36,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/VennDiagramOfMe.html
+++ b/levels/Level0/Recipes/VennDiagramOfMe.html
@@ -53,8 +53,7 @@ where red, green, blue, and opacity are all numbers between 0 and 255. So to mak
 <pre>textSize(sizeOfLetters);</pre>                                
                         </li>
                     </ol>
-        <a href="https://processing.org/reference">
-<img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                     <div style="clear:both;"></div>
                 </div>
             </div>

--- a/levels/Level0/Recipes/WheresWaldo.html
+++ b/levels/Level0/Recipes/WheresWaldo.html
@@ -28,8 +28,7 @@
 </li>  
             <li>Make sure you SAVE YOUR CODE when you are done. 
             </li> </ol>
-            <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
     <div style="clear:both;"></div></div></div></div></div><div id="footer"><script>addRecipeFooter();</script></div>
   </body>
 </html>

--- a/levels/Level0/Recipes/ZombieEyes.html
+++ b/levels/Level0/Recipes/ZombieEyes.html
@@ -69,8 +69,7 @@ fill(red, green, blue);
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
                                 </li>
                             </ol>
-            <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level0/Recipes/oldGooglyEyes.html
+++ b/levels/Level0/Recipes/oldGooglyEyes.html
@@ -40,8 +40,7 @@ PImage face = loadImage(&quot;face.jpeg&quot;);<br>
 image(face, 0, 0);
 </p>
 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+<div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
   
 <script src="https://league-level0.github.io/copyright.js"></script>
 

--- a/levels/Level0/Recipes/rocketShipBlastoff.html
+++ b/levels/Level0/Recipes/rocketShipBlastoff.html
@@ -39,8 +39,7 @@
                                 <li>Make sure you SAVE YOUR CODE when you are done. 
 </li>
                             </ol>
-                <a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+                            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
                             <div style="clear:both;"></div>
                         </div>
                     </div>

--- a/levels/Level1/Mod0Recipes/FlappyBird.html
+++ b/levels/Level1/Mod0Recipes/FlappyBird.html
@@ -155,8 +155,7 @@ ellipse(x, y, width, height);
  
         
         
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
     </div>
     </div>

--- a/levels/Level1/Mod0Recipes/MagicWorms.html
+++ b/levels/Level1/Mod0Recipes/MagicWorms.html
@@ -84,8 +84,7 @@
 <p class="normal">
 11. [Optional] Add another worm every time the user clicks the mouse.</p><br>
 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+<div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level1/Mod0Recipes/RainGame.html
+++ b/levels/Level1/Mod0Recipes/RainGame.html
@@ -86,8 +86,7 @@
     text("Score: " + score, 20, 20);</pre><br>
            
 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level1/Mod0Recipes/SpinningRecord.html
+++ b/levels/Level1/Mod0Recipes/SpinningRecord.html
@@ -70,8 +70,7 @@ We are going to make a virtual record player that spins and plays your song when
     </p><br>
 
 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level1/Mod3Recipes/FlappyBird.html
+++ b/levels/Level1/Mod3Recipes/FlappyBird.html
@@ -155,8 +155,7 @@ ellipse(x, y, width, height);
  
         
         
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
     </div>
     </div>

--- a/levels/Level1/Mod3Recipes/Frogger.html
+++ b/levels/Level1/Mod3Recipes/Frogger.html
@@ -163,8 +163,7 @@
     }
      </pre><br>
 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+     <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level2/Mod0Recipes/vangogh.html
+++ b/levels/Level2/Mod0Recipes/vangogh.html
@@ -28,8 +28,7 @@
 
             <br><br>
 
-            <a href="https://processing.org/reference">
-            <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+    <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
         </div>
     </div>
 </div>

--- a/levels/Level2/Mod2Recipes/Snake.html
+++ b/levels/Level2/Mod2Recipes/Snake.html
@@ -114,8 +114,7 @@ Call the drawFood and drawSnake methods.
                </p>  
 
  <br> <br> <br> 
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+ <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level2/Mod2Recipes/Snake2.html
+++ b/levels/Level2/Mod2Recipes/Snake2.html
@@ -87,8 +87,7 @@ Add code to this method to check if the head is in the same spot as the piece of
                     <li>If the snake moves over the food, a new piece of food should be drawn.</li>
                     </ul>
               <br><br>
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+<div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level2/Mod2Recipes/Snake3.html
+++ b/levels/Level2/Mod2Recipes/Snake3.html
@@ -74,8 +74,7 @@
                     <li>When the tail is long enough, test the snake shrinks when the head crosses the tail</li>
                     </ul>
               <br><br>
-<a href="https://processing.org/reference">
-    <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+<div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
 
                 </div>
     </div>

--- a/levels/Level3/Mod1Recipes/RetroSun.html
+++ b/levels/Level3/Mod1Recipes/RetroSun.html
@@ -232,8 +232,7 @@ class Reflection {
 }
             </pre>
 
-            <a href="https://processing.org/reference">
-            <img src="https://league-level0.github.io/p3logo.jpeg" class="footer" alt="Processing Reference"></a>
+            <div id="p3link"><script>addRecipeP3ReferenceLink()</script></div>
         </div>
     </div>
 </div>

--- a/script/headerAndFooter.js
+++ b/script/headerAndFooter.js
@@ -54,6 +54,14 @@ function addRecipeHeaderSmall(){
     
 }
 
+function addRecipeP3ReferenceLink() {
+    document.getElementById("p3link").innerHTML +=
+        "<a href=\"https://processing.org/reference\"> <div>                            \
+            <img src=\"https://league-level0.github.io/p3logo.jpeg\" alt=\"P3 Logo\">   \
+            <h4>Processing Reference</h4>                                               \
+        </div> </a>";
+}
+
 function addRecipeFooter(){
     var footer = document.getElementById("footer");
 

--- a/style/style.css
+++ b/style/style.css
@@ -351,6 +351,38 @@ hr {
    }
 
 
+/*** P3 Reference Link ***/
+
+#p3link {
+    float: left;
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+}
+
+    #p3link div {
+        box-shadow: 0 0.25em 0.5em gray;
+        padding: 1px 8px 1px 5px;
+
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+    }
+
+    #p3link img {
+        width: auto;
+        max-height: 100px;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    #p3link h4 {
+        max-width: min-content;
+    }
+
+
 /*** Tips Pages ***/
 
 #tipsPage {


### PR DESCRIPTION
Improve look of the P3 reference link found on many recipes
![image](https://user-images.githubusercontent.com/1296131/169981409-eb68ef66-603f-4778-afcd-95270d4ac148.png)

Old look had pretty bad stretching on most level 0 recipes
![image](https://user-images.githubusercontent.com/1296131/169981794-b4a79a0e-6085-4730-b7ec-e47149aaed69.png)
